### PR TITLE
Fixed scraper only scraping first episode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-horriblesubs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-horriblesubs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "An unofficial HorribleSubs API to scrape data from horriblesubs.info",
   "main": "src/index.js",
   "scripts": {

--- a/src/HorribleSubsAPI.js
+++ b/src/HorribleSubsAPI.js
@@ -81,7 +81,7 @@ class HorribleSubsAPI {
 
             let resolutions = [];
             qualities.forEach((quality, index) => {
-              let res = $(".link-" + quality);
+              let res = $(info_container).find(".link-" + quality);
               let magnet = res.find(".hs-magnet-link").find("a");
               let torrent = res.find(".hs-torrent-link").find("a");
               let xdc = res.find(".hs-xdcc-link").find("a");


### PR DESCRIPTION
So apparently there's an issue where the scraper only scrapes data from the first episode. At first I din't notice because in your test file it only logs the first items. 